### PR TITLE
Change visibility of PebbleTuple class

### DIFF
--- a/Android/PebbleKit/src/com/getpebble/android/kit/util/PebbleTuple.java
+++ b/Android/PebbleKit/src/com/getpebble/android/kit/util/PebbleTuple.java
@@ -9,7 +9,7 @@ import java.util.Map;
  *
  * @author zulak@getpebble.com
  */
-final class PebbleTuple {
+public final class PebbleTuple {
 
     private static final Charset UTF8 = Charset.forName("UTF-8");
 


### PR DESCRIPTION
Make PebbleTuple class public so we can iterate over the keys

``` java
for(PebbleTuple tuple : pebbleDictionary) {
    int key = tuple.key;        
}
```
