### PR TITLE
use utf-8 encoding for resources character regex string

### DIFF
--- a/Pebble/sdk/waftools/process_resources.py
+++ b/Pebble/sdk/waftools/process_resources.py
@@ -81,7 +81,7 @@ def gen_resource_deps(bld,
             else:
                 trackingAdjustArg = ''
             if 'characterRegex' in entry:
-                characterRegexArg = '--filter "%s"' % entry['characterRegex']
+                characterRegexArg = '--filter "%s"' % entry['characterRegex'].encode('utf-8')
             else:
                 characterRegexArg = ''
             bld(rule = "python {} pfo {} {} {} {} {}".format(font_script.abspath(),


### PR DESCRIPTION
this was breaking when attempting to build the WeatherWatch app by Katharine:
https://github.com/Katharine/WeatherWatch
