### PR TITLE
Fix Python module import in font2png.py

### DIFF
--- a/Pebble/watches/big_time/fonttools/font2png.py
+++ b/Pebble/watches/big_time/fonttools/font2png.py
@@ -42,7 +42,8 @@
 # canvas of the correct size.
 #
 
-import ImageFont, ImageDraw, Image
+import ImageFont, ImageDraw
+from PIL import Image
 
 FONT_SIZE = 100
 FONT_FILE_PATH = "resources/src/fonts/nevis.ttf"


### PR DESCRIPTION
Several people have had an issue with font2png.py where it fails to run.
See [this forum thread](http://forums.getpebble.com/discussion/6217/problem-regenerating-font-in-big-time#latest) for details.

Turns out Python is importing the wrong Image module.
This will force Python to import PIL.Image and not any other module.
