### PR TITLE
Branch to v2.x and increase the SDK version

### DIFF
--- a/Pebble/sdk/include/pebble_app_info.h
+++ b/Pebble/sdk/include/pebble_app_info.h
@@ -32,12 +32,12 @@ typedef enum {
 // struct_version (little endian):
 // 0x0800 -- sdk_version and app_version uint16_t fields added (Grand Slam / 1.7)
 // .major:0x08 .minor:0x01 -- all version fields split up into minor/major; uuid field appended (Junior Whopper / 2.0?)
-// sdk.major:4 -- Bump the SDK version to make 1.x and 2.x apps distinguishable
+// sdk.major:4 .minor:0 -- Bump the SDK version to make 1.x and 2.x apps distinguishable
 
 #define APP_INFO_CURRENT_STRUCT_VERSION_MINOR 0x1
 #define APP_INFO_CURRENT_STRUCT_VERSION_MAJOR 0x8
 #define APP_INFO_CURRENT_SDK_VERSION_MAJOR 0x4
-#define APP_INFO_CURRENT_SDK_VERSION_MINOR 0x3
+#define APP_INFO_CURRENT_SDK_VERSION_MINOR 0x0
 #define APP_NAME_BYTES 32
 #define COMPANY_NAME_BYTES 32
 

--- a/Pebble/sdk/include/pebble_app_info.h
+++ b/Pebble/sdk/include/pebble_app_info.h
@@ -32,10 +32,11 @@ typedef enum {
 // struct_version (little endian):
 // 0x0800 -- sdk_version and app_version uint16_t fields added (Grand Slam / 1.7)
 // .major:0x08 .minor:0x01 -- all version fields split up into minor/major; uuid field appended (Junior Whopper / 2.0?)
+// sdk.major:4 -- Bump the SDK version to make 1.x and 2.x apps distinguishable
 
 #define APP_INFO_CURRENT_STRUCT_VERSION_MINOR 0x1
 #define APP_INFO_CURRENT_STRUCT_VERSION_MAJOR 0x8
-#define APP_INFO_CURRENT_SDK_VERSION_MAJOR 0x3
+#define APP_INFO_CURRENT_SDK_VERSION_MAJOR 0x4
 #define APP_INFO_CURRENT_SDK_VERSION_MINOR 0x3
 #define APP_NAME_BYTES 32
 #define COMPANY_NAME_BYTES 32


### PR DESCRIPTION
This will automatically prevent 1.x apps running on 2.x firmware,
and vice-versa.  This has a matching change in tintin.

NOTE: I don't intend to pull this, but I want someone to confirm that we do want to have a separate branch for v2.x.  Having a separate branch requires more integrations, but allows bugfixes to the 1.x we currently ship between now and 2.x release.
